### PR TITLE
ARTDEV-15192 fixing auto sync status when file loaded

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/python/2.83.18/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/2.83.18/unity_mesh_sync.py
@@ -109,6 +109,9 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
     bl_idname = "meshsync.auto_sync"
     bl_label = "Auto Sync"
     _timer = None
+    
+    def __del__(self):
+        MESHSYNC_OT_AutoSync._timer = None
 
     def invoke(self, context, event):
         scene = bpy.context.scene

--- a/Plugins~/Src/MeshSyncClientBlender/python/2.90.1/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/2.90.1/unity_mesh_sync.py
@@ -109,6 +109,9 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
     bl_idname = "meshsync.auto_sync"
     bl_label = "Auto Sync"
     _timer = None
+    
+    def __del__(self):
+        MESHSYNC_OT_AutoSync._timer = None
 
     def invoke(self, context, event):
         scene = bpy.context.scene

--- a/Plugins~/Src/MeshSyncClientBlender/python/2.91.2/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/2.91.2/unity_mesh_sync.py
@@ -109,6 +109,9 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
     bl_idname = "meshsync.auto_sync"
     bl_label = "Auto Sync"
     _timer = None
+    
+    def __del__(self):
+        MESHSYNC_OT_AutoSync._timer = None
 
     def invoke(self, context, event):
         scene = bpy.context.scene

--- a/Plugins~/Src/MeshSyncClientBlender/python/2.92.0/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/2.92.0/unity_mesh_sync.py
@@ -109,6 +109,9 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
     bl_idname = "meshsync.auto_sync"
     bl_label = "Auto Sync"
     _timer = None
+    
+    def __del__(self):
+        MESHSYNC_OT_AutoSync._timer = None
 
     def invoke(self, context, event):
         scene = bpy.context.scene

--- a/Plugins~/Src/MeshSyncClientBlender/python/2.93.7/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/2.93.7/unity_mesh_sync.py
@@ -109,6 +109,9 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
     bl_idname = "meshsync.auto_sync"
     bl_label = "Auto Sync"
     _timer = None
+    
+    def __del__(self):
+        MESHSYNC_OT_AutoSync._timer = None
 
     def invoke(self, context, event):
         scene = bpy.context.scene

--- a/Plugins~/Src/MeshSyncClientBlender/python/3.0.1/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/3.0.1/unity_mesh_sync.py
@@ -109,6 +109,9 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
     bl_idname = "meshsync.auto_sync"
     bl_label = "Auto Sync"
     _timer = None
+    
+    def __del__(self):
+        MESHSYNC_OT_AutoSync._timer = None
 
     def invoke(self, context, event):
         scene = bpy.context.scene


### PR DESCRIPTION
Bugfix for
https://jira.unity3d.com/browse/ARTDEV-15192

The __end__ will be called after the invoke in all cases. When the file is loaded, the modal will be stopped and the __end__ is called. This will switch off the auto sync and the button will be rendered correctly (play). If the user clicks on auto sync again, the sync will continue. Tested on all blender versions which have a corresponding .py file