### PR TITLE
Fix: 3ds Max 2022, 2023+ compatibility 

### DIFF
--- a/Plugins~/CMakeLists.txt
+++ b/Plugins~/CMakeLists.txt
@@ -151,24 +151,33 @@ endforeach(CUR_BLENDER_VER)
 
 # ----------------------------------------------------------------------------------------------------------------------
 
-# 3DSMAX (Windows only)
+# 3DSMAX (Windows only) 
+# JW 2022/4: out of this list, only versions with installed SDK are getting build 
+
 list(APPEND 3DSMAX_VERSIONS
     3DSMAX_2018
     3DSMAX_2019
     3DSMAX_2020
     3DSMAX_2021
+    3DSMAX_2022
+    3DSMAX_2023
+    3DSMAX_2024
 ) 
 if(BUILD_3DSMAX_ALL)
     foreach(CUR_3DSMAX_VER IN LISTS 3DSMAX_VERSIONS)
-        option(BUILD_${CUR_3DSMAX_VER}_PLUGIN "Build MeshSync Plugin for ${CUR_3DSMAX_VER}" ON)
+		option(BUILD_${CUR_3DSMAX_VER}_PLUGIN "Build MeshSync Plugin for ${CUR_3DSMAX_VER}" ON)
     endforeach(CUR_3DSMAX_VER)   
 endif()
 
 if(WIN32)
 	foreach(CUR_3DSMAX_VER IN LISTS 3DSMAX_VERSIONS)
-		option(BUILD_${CUR_3DSMAX_VER}_PLUGIN "Build MeshSync Plugin for ${CUR_3DSMAX_VER}" OFF)
-		if (BUILD_${CUR_3DSMAX_VER}_PLUGIN)
-			add_subdirectory_link(MeshSyncClient${CUR_3DSMAX_VER} MeshSyncClient3dsMax)
+		string(REPLACE "3DSMAX_" "ADSK_3DSMAX_SDK_" CUR_3DSMAX_SDK ${CUR_3DSMAX_VER})
+		if(DEFINED ENV{${CUR_3DSMAX_SDK}})
+			message(STATUS "3ds Max SDK environment found: ${CUR_3DSMAX_SDK}") 
+			option(BUILD_${CUR_3DSMAX_VER}_PLUGIN "Build MeshSync Plugin for ${CUR_3DSMAX_VER}" OFF)
+			if (BUILD_${CUR_3DSMAX_VER}_PLUGIN)
+				add_subdirectory_link(MeshSyncClient${CUR_3DSMAX_VER} MeshSyncClient3dsMax)
+			endif()
 		endif()
 	endforeach(CUR_3DSMAX_VER)   
 endif()

--- a/Plugins~/Src/MeshSyncClient3dsMax/msmaxContext.cpp
+++ b/Plugins~/Src/MeshSyncClient3dsMax/msmaxContext.cpp
@@ -615,8 +615,14 @@ void msmaxContext::WaitAndKickAsyncExport()
     for (std::map<INode*, TreeNode>::value_type& kvp : m_node_records)
         kvp.second.clearState();
 
-
+#if MAX_VERSION_MAJOR <= 23
+	// 3ds Max 2021 and earlier
     float to_meter = static_cast<float>(GetMasterScale(UNITS_METERS));
+#else
+	// 3ds Max 2022 and later
+    float to_meter = static_cast<float>(GetSystemUnitScale(UNITS_METERS));
+#endif
+
     using Exporter = ms::SceneExporter;
     Exporter *exporter = m_settings.ExportSceneCache ? (Exporter*)&m_cache_writer : (Exporter*)&m_sender;
 
@@ -948,7 +954,15 @@ void msmaxContext::extractCameraData(TreeNode& n, TimeValue t,
     }
 
     if (auto* pcam = dynamic_cast<MaxSDK::IPhysicalCamera*>(cam)) {
-        float to_mm = (float)GetMasterScale(UNITS_MILLIMETERS);
+
+#if MAX_VERSION_MAJOR <= 23
+		// 3ds Max 2021 and earlier
+		float to_mm = (float)GetMasterScale(UNITS_MILLIMETERS);
+#else
+		// 3ds Max 2022 and later
+		float to_mm = (float)GetSystemUnitScale(UNITS_MILLIMETERS);
+#endif
+
         Interval interval;
 
         // focal length in mm
@@ -1451,7 +1465,13 @@ void msmaxContext::doExtractMeshData(ms::Mesh &dst, INode *n, Mesh *mesh)
                         frame.points[vi] = to_float3(channel.GetProgressiveMorphPoint(ti, vi)) - dst.points[vi];
                 }
                 if (!dbs->frames.empty()) {
+#if MAX_VERSION_MAJOR <= 23
+					// 3ds Max 2021 and earlier
                     dbs->name = mu::ToMBS(channel.GetName());
+#else
+					// 3ds Max 2022 and later
+					dbs->name = mu::ToMBS(channel.GetName(false));
+#endif
                     dbs->weight = channel.GetMorphWeight(t);
                     dst.blendshapes.push_back(dbs);
                 }
@@ -1600,8 +1620,13 @@ void msmaxContext::extractMeshAnimation(ms::TransformAnimation& dst_, TreeNode *
                 auto tnode = channel.GetMorphTarget();
                 if (!tnode || !channel.IsActive() || !channel.IsValid())
                     continue;
-
-                auto name = mu::ToMBS(channel.GetName());
+#if MAX_VERSION_MAJOR <= 23
+				// 3ds Max 2021 and earlier
+				auto name = mu::ToMBS(channel.GetName());
+#else
+				// 3ds Max 2022 and later
+				auto name = mu::ToMBS(channel.GetName(false));
+#endif                
                 dst.getBlendshapeCurve(name).push_back({ t, channel.GetMorphWeight(m_current_time_tick) });
             }
         }


### PR DESCRIPTION
Fix compatibility for 3ds Max 2022, 2023 and future 3ds Max SDKs
Add filtering of non-installed 3ds Max SDK versions to CmakeLists