### PR TITLE
Fix: geometry node instances

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/msblenGeometryNodesUtils.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenGeometryNodesUtils.cpp
@@ -92,6 +92,10 @@ namespace blender {
                 if (rec == records_by_name.end())
                     continue;
 
+                // Sometimes an object in the data might come up more than once
+                if (rec->second->handled)
+                    continue;
+
                 // Check if the data names also match
                 auto recDataId = (ID*)rec->second->object_copy.data;
                 auto sceneDataId = (ID*)obj->data;


### PR DESCRIPTION
There is a bug where we would handle the same instances record more than once when extracting geometry node instances. This is causing issues as we move the matrices of the record instead of copying them: the matrices reference in the record should not be reused. More about std::move here https://en.cppreference.com/w/cpp/utility/move

The fix is to avoid handling the record is it has been already handled.