### PR TITLE
blender-fix: make AutoSync work again after loading a new file

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/python/2.83.18/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/2.83.18/unity_mesh_sync.py
@@ -109,18 +109,18 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
     bl_idname = "meshsync.auto_sync"
     bl_label = "Auto Sync"
     _timer = None
-    
+    _registered = False
+
     def __del__(self):
         MESHSYNC_OT_AutoSync._timer = None
 
     def execute(self, context):
         return self.invoke(context, None)
-        
+
     # When a file is loaded, the modal registration is reset:
     @persistent
     def load_handler(dummy):
         MESHSYNC_OT_AutoSync._registered = False
-        bpy.app.handlers.load_post.remove(MESHSYNC_OT_AutoSync.load_handler)
 
     def invoke(self, context, event):
         scene = bpy.context.scene
@@ -129,15 +129,21 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
             if not scene.meshsync_auto_sync:
                 # server not available
                 return {'FINISHED'}
-            MESHSYNC_OT_AutoSync._timer = context.window_manager.event_timer_add(1.0 / 3.0, window=context.window)
-                        
+            update_step = 0.01 # 1.0/3.0
+            MESHSYNC_OT_AutoSync._timer = context.window_manager.event_timer_add(update_step, window=context.window)
+
             # There is no way to unregister modal callbacks!
             # To ensure this does not get repeatedly registered, keep track of it and only do it once:
             if not MESHSYNC_OT_AutoSync._registered:
                 context.window_manager.modal_handler_add(self)
                 MESHSYNC_OT_AutoSync._registered = True
-                bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
-                
+
+            if bpy.app.background:
+                import time
+                while True:
+                    time.sleep(update_step)
+                    self.update()
+
             return {'RUNNING_MODAL'}
         else:
             scene.meshsync_auto_sync = False
@@ -303,6 +309,7 @@ classes = (
 
 def register():
     msb_initialize_properties()
+    bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
     for c in classes:
         bpy.utils.register_class(c)
 

--- a/Plugins~/Src/MeshSyncClientBlender/python/2.90.1/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/2.90.1/unity_mesh_sync.py
@@ -115,6 +115,12 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
 
     def execute(self, context):
         return self.invoke(context, None)
+        
+    # When a file is loaded, the modal registration is reset:
+    @persistent
+    def load_handler(dummy):
+        MESHSYNC_OT_AutoSync._registered = False
+        bpy.app.handlers.load_post.remove(MESHSYNC_OT_AutoSync.load_handler)
 
     def invoke(self, context, event):
         scene = bpy.context.scene
@@ -124,7 +130,14 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
                 # server not available
                 return {'FINISHED'}
             MESHSYNC_OT_AutoSync._timer = context.window_manager.event_timer_add(1.0 / 3.0, window=context.window)
-            context.window_manager.modal_handler_add(self)
+            
+            # There is no way to unregister modal callbacks!
+            # To ensure this does not get repeatedly registered, keep track of it and only do it once:
+            if not MESHSYNC_OT_AutoSync._registered:
+                context.window_manager.modal_handler_add(self)
+                MESHSYNC_OT_AutoSync._registered = True
+                bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
+                
             return {'RUNNING_MODAL'}
         else:
             scene.meshsync_auto_sync = False

--- a/Plugins~/Src/MeshSyncClientBlender/python/2.90.1/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/2.90.1/unity_mesh_sync.py
@@ -109,18 +109,18 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
     bl_idname = "meshsync.auto_sync"
     bl_label = "Auto Sync"
     _timer = None
-    
+    _registered = False
+
     def __del__(self):
         MESHSYNC_OT_AutoSync._timer = None
 
     def execute(self, context):
         return self.invoke(context, None)
-        
+
     # When a file is loaded, the modal registration is reset:
     @persistent
     def load_handler(dummy):
         MESHSYNC_OT_AutoSync._registered = False
-        bpy.app.handlers.load_post.remove(MESHSYNC_OT_AutoSync.load_handler)
 
     def invoke(self, context, event):
         scene = bpy.context.scene
@@ -136,8 +136,13 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
             if not MESHSYNC_OT_AutoSync._registered:
                 context.window_manager.modal_handler_add(self)
                 MESHSYNC_OT_AutoSync._registered = True
-                bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
-                
+
+            if bpy.app.background:
+                import time
+                while True:
+                    time.sleep(update_step)
+                    self.update()
+
             return {'RUNNING_MODAL'}
         else:
             scene.meshsync_auto_sync = False
@@ -303,6 +308,7 @@ classes = (
 
 def register():
     msb_initialize_properties()
+    bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
     for c in classes:
         bpy.utils.register_class(c)
 

--- a/Plugins~/Src/MeshSyncClientBlender/python/2.91.2/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/2.91.2/unity_mesh_sync.py
@@ -115,6 +115,12 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
 
     def execute(self, context):
         return self.invoke(context, None)
+        
+    # When a file is loaded, the modal registration is reset:
+    @persistent
+    def load_handler(dummy):
+        MESHSYNC_OT_AutoSync._registered = False
+        bpy.app.handlers.load_post.remove(MESHSYNC_OT_AutoSync.load_handler)
 
     def invoke(self, context, event):
         scene = bpy.context.scene
@@ -124,7 +130,14 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
                 # server not available
                 return {'FINISHED'}
             MESHSYNC_OT_AutoSync._timer = context.window_manager.event_timer_add(1.0 / 3.0, window=context.window)
-            context.window_manager.modal_handler_add(self)
+            
+            # There is no way to unregister modal callbacks!
+            # To ensure this does not get repeatedly registered, keep track of it and only do it once:
+            if not MESHSYNC_OT_AutoSync._registered:
+                context.window_manager.modal_handler_add(self)
+                MESHSYNC_OT_AutoSync._registered = True
+                bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
+                
             return {'RUNNING_MODAL'}
         else:
             scene.meshsync_auto_sync = False

--- a/Plugins~/Src/MeshSyncClientBlender/python/2.92.0/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/2.92.0/unity_mesh_sync.py
@@ -115,6 +115,12 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
 
     def execute(self, context):
         return self.invoke(context, None)
+        
+    # When a file is loaded, the modal registration is reset:
+    @persistent
+    def load_handler(dummy):
+        MESHSYNC_OT_AutoSync._registered = False
+        bpy.app.handlers.load_post.remove(MESHSYNC_OT_AutoSync.load_handler)
 
     def invoke(self, context, event):
         scene = bpy.context.scene
@@ -124,7 +130,14 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
                 # server not available
                 return {'FINISHED'}
             MESHSYNC_OT_AutoSync._timer = context.window_manager.event_timer_add(1.0 / 3.0, window=context.window)
-            context.window_manager.modal_handler_add(self)
+            
+            # There is no way to unregister modal callbacks!
+            # To ensure this does not get repeatedly registered, keep track of it and only do it once:
+            if not MESHSYNC_OT_AutoSync._registered:
+                context.window_manager.modal_handler_add(self)
+                MESHSYNC_OT_AutoSync._registered = True
+                bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
+                
             return {'RUNNING_MODAL'}
         else:
             scene.meshsync_auto_sync = False

--- a/Plugins~/Src/MeshSyncClientBlender/python/2.93.7/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/2.93.7/unity_mesh_sync.py
@@ -109,19 +109,19 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
     bl_idname = "meshsync.auto_sync"
     bl_label = "Auto Sync"
     _timer = None
-    
+    _registered = False
+
     def __del__(self):
         MESHSYNC_OT_AutoSync._timer = None
 
     def execute(self, context):
         return self.invoke(context, None)
-    
+
     # When a file is loaded, the modal registration is reset:
     @persistent
     def load_handler(dummy):
         MESHSYNC_OT_AutoSync._registered = False
-        bpy.app.handlers.load_post.remove(MESHSYNC_OT_AutoSync.load_handler)
-        
+
     def invoke(self, context, event):
         scene = bpy.context.scene
         if not MESHSYNC_OT_AutoSync._timer:
@@ -129,15 +129,21 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
             if not scene.meshsync_auto_sync:
                 # server not available
                 return {'FINISHED'}
-            MESHSYNC_OT_AutoSync._timer = context.window_manager.event_timer_add(1.0 / 3.0, window=context.window)
-            
+            update_step = 0.01 # 1.0/3.0
+            MESHSYNC_OT_AutoSync._timer = context.window_manager.event_timer_add(update_step, window=context.window)
+
             # There is no way to unregister modal callbacks!
             # To ensure this does not get repeatedly registered, keep track of it and only do it once:
             if not MESHSYNC_OT_AutoSync._registered:
                 context.window_manager.modal_handler_add(self)
                 MESHSYNC_OT_AutoSync._registered = True
-                bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
-                
+
+            if bpy.app.background:
+                import time
+                while True:
+                    time.sleep(update_step)
+                    self.update()
+
             return {'RUNNING_MODAL'}
         else:
             scene.meshsync_auto_sync = False
@@ -303,6 +309,7 @@ classes = (
 
 def register():
     msb_initialize_properties()
+    bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
     for c in classes:
         bpy.utils.register_class(c)
 

--- a/Plugins~/Src/MeshSyncClientBlender/python/2.93.7/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/2.93.7/unity_mesh_sync.py
@@ -115,7 +115,13 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
 
     def execute(self, context):
         return self.invoke(context, None)
-
+    
+    # When a file is loaded, the modal registration is reset:
+    @persistent
+    def load_handler(dummy):
+        MESHSYNC_OT_AutoSync._registered = False
+        bpy.app.handlers.load_post.remove(MESHSYNC_OT_AutoSync.load_handler)
+        
     def invoke(self, context, event):
         scene = bpy.context.scene
         if not MESHSYNC_OT_AutoSync._timer:
@@ -124,7 +130,14 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
                 # server not available
                 return {'FINISHED'}
             MESHSYNC_OT_AutoSync._timer = context.window_manager.event_timer_add(1.0 / 3.0, window=context.window)
-            context.window_manager.modal_handler_add(self)
+            
+            # There is no way to unregister modal callbacks!
+            # To ensure this does not get repeatedly registered, keep track of it and only do it once:
+            if not MESHSYNC_OT_AutoSync._registered:
+                context.window_manager.modal_handler_add(self)
+                MESHSYNC_OT_AutoSync._registered = True
+                bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
+                
             return {'RUNNING_MODAL'}
         else:
             scene.meshsync_auto_sync = False

--- a/Plugins~/Src/MeshSyncClientBlender/python/3.0.1/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/3.0.1/unity_mesh_sync.py
@@ -110,19 +110,19 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
     bl_idname = "meshsync.auto_sync"
     bl_label = "Auto Sync"
     _timer = None
-    
+    _registered = False
+
     def __del__(self):
         MESHSYNC_OT_AutoSync._timer = None
 
     def execute(self, context):
         return self.invoke(context, None)
-    
-     # When a file is loaded, the modal registration is reset:
+
+    # When a file is loaded, the modal registration is reset:
     @persistent
     def load_handler(dummy):
         MESHSYNC_OT_AutoSync._registered = False
-        bpy.app.handlers.load_post.remove(MESHSYNC_OT_AutoSync.load_handler)
-        
+
     def invoke(self, context, event):
         scene = bpy.context.scene
         if not MESHSYNC_OT_AutoSync._timer:
@@ -130,16 +130,15 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
             if not scene.meshsync_auto_sync:
                 # server not available
                 return {'FINISHED'}
-            update_step = 0.0001 # 1.0/3.0
+            update_step = 0.01 # 1.0/3.0
             MESHSYNC_OT_AutoSync._timer = context.window_manager.event_timer_add(update_step, window=context.window)
-            
+
             # There is no way to unregister modal callbacks!
             # To ensure this does not get repeatedly registered, keep track of it and only do it once:
             if not MESHSYNC_OT_AutoSync._registered:
                 context.window_manager.modal_handler_add(self)
                 MESHSYNC_OT_AutoSync._registered = True
-                bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
-                
+
             if bpy.app.background:
                 import time
                 while True:
@@ -313,6 +312,7 @@ classes = (
 
 def register():
     msb_initialize_properties()
+    bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
     for c in classes:
         bpy.utils.register_class(c)
 

--- a/Plugins~/Src/MeshSyncClientBlender/python/3.1.0/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/3.1.0/unity_mesh_sync.py
@@ -132,7 +132,6 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
     @persistent
     def load_handler(dummy):
         MESHSYNC_OT_AutoSync._registered = False
-        bpy.app.handlers.load_post.remove(MESHSYNC_OT_AutoSync.load_handler)
 
     def invoke(self, context, event):
         scene = bpy.context.scene
@@ -149,7 +148,6 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
             if not MESHSYNC_OT_AutoSync._registered:
                 context.window_manager.modal_handler_add(self)
                 MESHSYNC_OT_AutoSync._registered = True
-                bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
 
             if bpy.app.background:
                 import time
@@ -323,6 +321,7 @@ classes = (
 
 def register():
     msb_initialize_properties()
+    bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
     for c in classes:
         bpy.utils.register_class(c)
 

--- a/Plugins~/Src/MeshSyncClientBlender/python/3.1.0/unity_mesh_sync.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/3.1.0/unity_mesh_sync.py
@@ -128,6 +128,12 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
     def execute(self, context):
         return self.invoke(context, None)
 
+    # When a file is loaded, the modal registration is reset:
+    @persistent
+    def load_handler(dummy):
+        MESHSYNC_OT_AutoSync._registered = False
+        bpy.app.handlers.load_post.remove(MESHSYNC_OT_AutoSync.load_handler)
+
     def invoke(self, context, event):
         scene = bpy.context.scene
         if not MESHSYNC_OT_AutoSync._timer:
@@ -143,6 +149,7 @@ class MESHSYNC_OT_AutoSync(bpy.types.Operator):
             if not MESHSYNC_OT_AutoSync._registered:
                 context.window_manager.modal_handler_add(self)
                 MESHSYNC_OT_AutoSync._registered = True
+                bpy.app.handlers.load_post.append(MESHSYNC_OT_AutoSync.load_handler)
 
             if bpy.app.background:
                 import time


### PR DESCRIPTION
Ensure python callback is only registered once to avoid getting too many callbacks.