### PR TITLE
blender-fix: Blender settings apply differently depending on the order of using Manual Sync vs Animation Sync

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_common.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_common.py
@@ -116,6 +116,7 @@ class MESHSYNC_OT_SendAnimations(bpy.types.Operator):
     bl_idname = "meshsync.send_animations"
     bl_label = "Export Animations"
     def execute(self, context):
+        msb_apply_scene_settings()
         msb_apply_animation_settings()
         msb_context.setup(bpy.context);
         msb_context.export(msb_context.TARGET_ANIMATIONS)


### PR DESCRIPTION
There is an inconsistency when applying the UI settings.

Scenario 1: The user exports the animations first and the meshes later. Result: Only the animation settings are applied. The scene settings are ignored. The Bake Transform option uses the default value (false) which will result in exporting keyframes with the values from the dope sheet.

Scenario 2: The user exports the scene first and the animations later. Result: The scene and the animation settings are applied. The Bake Transform option uses the user value (true) which will result in exporting keyframes with 0 values.

This solution ensures that the scene options are always applied. Does it make sense to use the Bake transform flag when exporting animations? A better solution might be using a different set of settings for each operation, i.e. the animation settings override the BakeTransform flag to false. 