### PR TITLE
blender-fix: Fix for accessing deform groups in Blender 3.0 and above

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/msblenUtils.h
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenUtils.h
@@ -73,8 +73,18 @@ inline void each_modifier(Object *obj, const Body& body)
 template<class Body>
 static inline void each_deform_group(const Object *obj, const Body& body)
 {
+    
+// defbase was deprecated after v2.94
+#if BLENDER_VERSION >= 300
+    auto mesh = (Mesh*)obj->data;
+    auto names = mesh->vertex_group_names;
+    for (auto* it = (const bDeformGroup*)names.first; it != nullptr; it = it->next) {
+        body(it);
+    }
+#else
     for (auto *it = (const bDeformGroup*)obj->defbase.first; it != nullptr; it = it->next)
         body(it);
+#endif
 }
 
 // Body: [](const KeyBlock*) -> void

--- a/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_common.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_common.py
@@ -116,6 +116,7 @@ class MESHSYNC_OT_SendAnimations(bpy.types.Operator):
     bl_idname = "meshsync.send_animations"
     bl_label = "Export Animations"
     def execute(self, context):
+        msb_apply_scene_settings()
         msb_apply_animation_settings()
         msb_context.setup(bpy.context);
         msb_context.export(msb_context.TARGET_ANIMATIONS)


### PR DESCRIPTION
defbase was deprecated in Blender 3.0. This was creating an issue with exporting bones in the mesh. I added the new way to access the vertex groups in 3.0.