### PR TITLE
macOS: Fix for adding DCC tools 

### DIFF
--- a/MeshSyncDCCPlugins~/Assets/MeshSyncDCCPlugins/Editor/DebugInstallWindow.cs
+++ b/MeshSyncDCCPlugins~/Assets/MeshSyncDCCPlugins/Editor/DebugInstallWindow.cs
@@ -89,12 +89,9 @@ public class DebugInstallWindow : EditorWindow {
 
         Button chooseFolderButton = new Button();
         chooseFolderButton.text = "Choose Folder";
-        chooseFolderButton.clicked += () => {
-            string folder = EditorUtility.OpenFolderPanel("Add DCC Tool", manualTextField.value, "");
-            if (string.IsNullOrEmpty(folder)) {
-                return;
-            }
-            m_lastManualDir = manualTextField.value = folder;
+        chooseFolderButton.clicked += () =>
+        {
+            manualTextField.value = m_platformUtility.OpenDCCPathPanel();
         };
         labelParent.Add(chooseFolderButton);
                     
@@ -112,9 +109,8 @@ public class DebugInstallWindow : EditorWindow {
         container.Query<Button>("RemoveDCCToolButton").First().visible = false;
         top.Add(container);
     }
-    
-//----------------------------------------------------------------------------------------------------------------------        
 
+    //----------------------------------------------------------------------------------------------------------------------        
 
     void OnLaunchDCCToolButtonClicked(EventBase evt) {
         DCCToolInfo dccToolInfo = GetEventButtonUserDataAs<DCCToolInfo>(evt.target);           
@@ -273,6 +269,5 @@ public class DebugInstallWindow : EditorWindow {
     private VisualElement m_root = null;
     
     [SerializeField] private string m_lastManualDir = null;
-
-
+    private readonly PlatformUtility m_platformUtility = new PlatformUtility();
 }

--- a/MeshSyncDCCPlugins~/Assets/MeshSyncDCCPlugins/Editor/PlatformUtility.cs
+++ b/MeshSyncDCCPlugins~/Assets/MeshSyncDCCPlugins/Editor/PlatformUtility.cs
@@ -1,0 +1,45 @@
+using System.IO;
+using UnityEditor;
+using UnityEngine;
+
+public class PlatformUtility
+{
+    const string title = "Add DCC Tool";
+    public string OpenDCCPathPanel()
+    {
+        if (Application.platform == RuntimePlatform.OSXEditor)
+        {
+            return OpenFilePanel(title);
+        }
+        else
+        {
+            return OpenFolderPanel(title);
+        }
+    }
+    
+    private string m_lastManualDir;
+
+    private string OpenFolderPanel(string title)
+    {
+        string path = EditorUtility.OpenFolderPanel(title, m_lastManualDir, "");
+        if (string.IsNullOrEmpty(path))
+        {
+            return null;
+        }
+
+        m_lastManualDir = path;
+        return path;
+    }
+
+    private string OpenFilePanel(string title)
+    {
+        string file = EditorUtility.OpenFilePanel(title, m_lastManualDir, "");
+        if (string.IsNullOrEmpty(file))
+        {
+            return null;
+        }
+
+        m_lastManualDir = Path.GetDirectoryName(file);
+        return file;
+    }
+}

--- a/MeshSyncDCCPlugins~/Assets/MeshSyncDCCPlugins/Editor/PlatformUtility.cs.meta
+++ b/MeshSyncDCCPlugins~/Assets/MeshSyncDCCPlugins/Editor/PlatformUtility.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: 772698f5988b4e7883d89dbed37eef9d
+timeCreated: 1658227999


### PR DESCRIPTION
On macOS, application installations are bundled in .app files. The editor scripts were searching for folders only instead of files, which makes the add dcc tool button unusable for macOS. This PR addresses this issue by using opening either a file or a folder panel, depending on the platform.