### PR TITLE
blender-fix: fix for broken uvs on edit mode

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
@@ -1135,21 +1135,16 @@ void msblenContext::doExtractEditMeshData(msblenContextState& state, BlenderSync
 
     // uv
     if (settings.sync_uvs) {
-        //const int offset = emesh.uv_data_offset();
-        //if (offset != -1) {
-        //    dst.m_uv[0].resize_discard(num_indices);
-        //    size_t ii = 0;
-        //    for (size_t ti = 0; ti < num_triangles; ++ti) {
-        //        auto& triangle = triangles[ti];
-        //        for (auto *idx : triangle)
-        //            dst.m_uv[0][ii++] = *reinterpret_cast<mu::float2*>((char*)idx->head.data + offset);
-        //    }
-        //}
-        //
-        //
-        //
-        blender::BlenderUtility::ApplyBMeshUVToMesh(&bmesh, num_indices, &dst);
-
+        const int offset = emesh.uv_data_offset();
+        if (offset != -1) {
+            dst.m_uv[0].resize_discard(num_indices);
+            size_t ii = 0;
+            for (size_t ti = 0; ti < num_triangles; ++ti) {
+                auto& triangle = triangles[ti];
+                for (auto *idx : triangle)
+                    dst.m_uv[0][ii++] = *reinterpret_cast<mu::float2*>((char*)idx->head.data + offset);
+            }
+        }
     }
 }
 


### PR DESCRIPTION
The root cause seems to be that we are trying to extract UVs from the mesh while indices are extracted from the edit mesh. I noticed that the indices are different in number between the mesh and the edit mesh, and so I don't think we can map the uv coordinates between them, reliably. 

From the file history, the old solution was originally replaced to support multiple UV channels. I am not sure how we can support this now, but at least the UVs should be correct in the one channel we support. We should also call out this caveat in our docs. I can implement the docs change after we discuss this solution.

Potential fix for some of the issues reported here: https://github.com/unity3d-jp/MeshSync/issues/768