### PR TITLE
blender-fix: Use running editor server log to config client port

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_installation.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_installation.py
@@ -240,17 +240,6 @@ def msb_try_start_unity_project (context, directory):
 
     global unity_process
 
-    #Check if we have launched the project as a subprocess
-    if msb_is_unity_process_alive():
-        return 'ALREADY_STARTED'
-
-    #Check if there is an editor server listening from the target project
-    if msb_context.is_editor_server_available:
-        msb_context.sendEditorCommand(EDITOR_COMMAND_GET_PROJECT_PATH, None)
-        reply_path = msb_context.editor_command_reply;
-        if path.normpath(reply_path) == path.normpath(directory):
-            return 'ALREADY_STARTED'
-
     editor_version = msb_get_editor_version(directory)
     editor_path = msb_get_editor_path(context, editor_version)
 

--- a/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_installation.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_installation.py
@@ -28,6 +28,10 @@ def msb_is_project_open(directory):
                 import fcntl
                 fcntl.lockf(file.fileno(), fcntl.LOCK_EX|fcntl.LOCK_NB)
                 fcntl.lockf(file.fileno(), fcntl.LOCK_UN)
+            elif os == "Windows":
+                import msvcrt
+                msvcrt.locking(file.fileno(), msvcrt.LK_NBLCK, 0)
+                msvcrt.locking(file.fileno(), msvcrt.LK_UNLCK, 0)
     except:
         return True
 

--- a/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_installation.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_installation.py
@@ -17,6 +17,14 @@ msb_context = ms.Context()
 
 unity_process = None
 
+def msb_is_project_open(directory):
+    full_path = path.join(directory, "Temp")
+    if not path.exists(full_path):
+        return False
+
+    lock_path = path.join(full_path, "UnityLockfile")
+    return path.exists(full_path)
+
 def MS_MessageBox(message = "", title = "MeshSync", icon = 'INFO'):
     def draw(self, context):
         self.layout.label(text=message)
@@ -220,6 +228,10 @@ def msb_is_unity_process_alive():
 
 def msb_try_start_unity_project (context, directory):
         
+
+    if msb_is_project_open(directory):
+        return 'ALREADY_STARTED'
+
     global unity_process
 
     #Check if we have launched the project as a subprocess

--- a/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_installation.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_installation.py
@@ -21,11 +21,13 @@ def msb_is_project_open(directory):
     full_path = path.join(directory, "Temp", "UnityLockfile")
     if not path.exists(full_path):
         return False
-
-    #In case the editor has crashed and not cleaned up the Temp folder
     try:
-        file = open(full_path)
-        file.close()
+        with open(full_path, 'wb') as file:
+            os = platform.system()
+            if os == "Darwin" or os == "Linux":
+                import fcntl
+                fcntl.lockf(file.fileno(), fcntl.LOCK_EX|fcntl.LOCK_NB)
+                fcntl.lockf(file.fileno(), fcntl.LOCK_UN)
     except:
         return True
 

--- a/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_installation.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_installation.py
@@ -18,12 +18,18 @@ msb_context = ms.Context()
 unity_process = None
 
 def msb_is_project_open(directory):
-    full_path = path.join(directory, "Temp")
+    full_path = path.join(directory, "Temp", "UnityLockfile")
     if not path.exists(full_path):
         return False
 
-    lock_path = path.join(full_path, "UnityLockfile")
-    return path.exists(full_path)
+    #In case the editor has crashed and not cleaned up the Temp folder
+    try:
+        file = open(full_path)
+        file.close()
+    except:
+        return True
+
+    return False
 
 def MS_MessageBox(message = "", title = "MeshSync", icon = 'INFO'):
     def draw(self, context):


### PR DESCRIPTION
Depends on https://github.com/unity3d-jp/MeshSync/pull/809

Please review https://github.com/Unity-Technologies/MeshSyncDCCPlugins/pull/290 first.

Using the server log to make better decisions on auto-config. 