### PR TITLE
blender: auto-detect Unity hub and editor folders location (win, macOS)

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_installation.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_installation.py
@@ -373,3 +373,42 @@ def msb_try_auto_config_server_settings(context):
         context.scene.meshsync_editor_server_port = editorSocket.getsockname()[1]
         with closing(msb_bind_next_available_socket(context.scene.meshsync_server_port)) as sceneSocket:
             context.scene.meshsync_server_port = sceneSocket.getsockname()[1]
+
+def msb_get_hub_dir():
+    system = platform.system()
+    path = ""
+    if system == "Windows":
+        path = os.path.join(os.getenv('APPDATA'),"UnityHub")
+    elif system == "Darwin":
+        path = os.path.join(os.getenv("HOME"),"Library","Application Support","UnityHub")
+    #TODO Linux
+
+    return path
+
+def msb_get_hub_path():
+    hub_dir = msb_get_hub_dir()
+    if not os.path.exists(hub_dir):
+        return ""
+
+    config_path = os.path.join(hub_dir, "hubInfo.json")
+
+    if not os.path.exists(config_path):
+        return ""
+
+    with open(config_path, "r+") as file:
+        data = json.load(file)
+        path = os.path.normpath(data['executablePath'])
+        if not os.path.exists(path):
+            path = ""
+        return path
+
+def msb_get_editors_path():
+    path = msb_get_hub_path()
+    if not os.path.exists(path):
+        return ""
+
+    p = subprocess.Popen([path, "--", "--headless","ip", "-g" ], stdout = subprocess.PIPE)
+    path = None
+    for line in iter(p.stdout.readline, b''):
+        path = line.rstrip()
+    return path.decode('utf-8')

--- a/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_preferences.py
+++ b/Plugins~/Src/MeshSyncClientBlender/python/unity_mesh_sync_preferences.py
@@ -2,6 +2,7 @@ import bpy
 import os
 import platform
 
+from .unity_mesh_sync_installation import *
 from . import MeshSyncClientBlender as ms
 from bpy.types import AddonPreferences
 from bpy.props import StringProperty, IntProperty, BoolProperty
@@ -15,7 +16,20 @@ def msb_get_editor_path_prefix_default():
         path = "C:\\Program Files\\Unity\\Hub\\Editor"
     elif os == 'Darwin' or os == 'Linux':
         path = "/Applications/Unity/Hub/Editor"
-    return path;
+    return path
+
+class MESHSYNC_OT_ResetPreferences(bpy.types.Operator):
+    bl_idname = "meshsync.reset_preferences"
+    bl_label = "Reset Preferences"
+
+    @classmethod
+    def description(cls, context, properties):
+        return "Find where the Unity Hub and the Unity Editors are located in the system"
+
+    def execute(self, context):
+        preferences = context.preferences.addons[__package__].preferences
+        preferences.reset()
+        return {'FINISHED'}
 
 class MESHSYNC_Preferences(AddonPreferences):
 
@@ -23,10 +37,52 @@ class MESHSYNC_Preferences(AddonPreferences):
     # when defining this in a submodule of a python package.
     bl_idname = __package__
 
+    def hub_exists(self):
+        return os.path.exists(self.hub_path)
+
+    def editors_path_exists(self):
+        return os.path.exists(self.editors_path)
+
+    def is_hub_installed():
+        path = msb_get_hub_path()
+        return dir is not None and os.path.exists(path)
+
+    def reset(self):
+        self.hub_path = msb_get_hub_path()
+        self.editors_path = msb_get_editors_path()
+        self.hub_installed = MESHSYNC_Preferences.is_hub_installed()
+
     project_path: StringProperty(name = "Unity Project", default= "C:/", subtype = 'DIR_PATH')
     editors_path: bpy.props.StringProperty(name = "Unity Editors", default= msb_get_editor_path_prefix_default(), subtype = 'DIR_PATH')
+    hub_path: bpy.props.StringProperty(name = "Unity Hub", default = msb_get_hub_path(), subtype = 'FILE_PATH')
+    hub_installed : bpy.props.BoolProperty(name = "Hub Installed", default = is_hub_installed())
 
     def draw(self, context):
         layout = self.layout
-        layout.prop(self, "project_path")
-        layout.prop(self, "editors_path")
+        editor_layout = layout.box()
+        editor_layout.label(text ="Editor Settings")
+        editor_layout.prop(self, "hub_path")
+        editor_layout.prop(self, "editors_path")
+
+        if not self.hub_exists() and not self.hub_installed:
+            row = editor_layout.row()
+            row.label(text = "Could not detect Unity Hub installation.", icon = 'ERROR')
+            row.operator("wm.url_open", text="Download Unity Hub", icon = 'URL').url = "https://unity3d.com/get-unity/download"
+            row = editor_layout.row()
+            row.operator("meshsync.reset_preferences", text="Auto Detect", icon="FILE_REFRESH")
+        elif not self.hub_exists() or not self.editors_path_exists():
+            row = editor_layout.row()
+            row.label(text = "One of the paths above does not exist", icon = 'ERROR')
+            row.operator("meshsync.reset_preferences", text="Auto Detect", icon="FILE_REFRESH")
+        else:
+            editor_layout.operator("meshsync.reset_preferences", text="Auto Detect", icon="FILE_REFRESH")
+
+        project_layout = layout.box()
+        project_layout.label(text ="Project Settings")
+        project_layout.prop(self, "project_path")
+
+    def register():
+        bpy.utils.register_class(MESHSYNC_OT_ResetPreferences)
+
+    def unregister():
+        bpy.utils.unregister_class(MESHSYNC_OT_ResetPreferences)


### PR DESCRIPTION
Currently leaving out linux as I would prefer to create a separate PR for linux support at the end