### PR TITLE
blender-feat: support exporting empty objects.

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
@@ -372,10 +372,9 @@ ms::TransformPtr msblenContext::exportObject(msblenContextState& state, msblenCo
     }
     default:
     {
-        if (get_instance_collection(obj) || (!tip && parent)) {
-            handle_parent();
-            rec.dst = exportTransform(state, paths, settings, obj);
-        }
+        // Export everything, even if it's an empty object:
+        handle_parent();
+        rec.dst = exportTransform(state, paths, settings, obj);
         break;
     }
     }


### PR DESCRIPTION
This change makes meshsync export empty objects too to get a more accurate representation of the scene in blender.