### PR TITLE
blender-fix: export normals correctly in edit mode, taking polygon smooth into account

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
@@ -1122,10 +1122,10 @@ void msblenContext::doExtractEditMeshData(msblenContextState& state, BlenderSync
                 if (smooth) {
                     auto index =  idx->v->head.index;
                     auto vertext = vertices[index];
-                    dst.normals[ii++] = to_float3(vertext->no);
+                    dst.normals[ii++] = ms::ceilToDecimals(to_float3(vertext->no));
                 }
                 else {
-                    dst.normals[ii++] = to_float3(idx->f->no);
+                    dst.normals[ii++] = ms::ceilToDecimals(to_float3(idx->f->no));
                 }
             }
         }

--- a/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
@@ -1087,6 +1087,7 @@ void msblenContext::doExtractEditMeshData(msblenContextState& state, BlenderSync
         for (size_t ti = 0; ti < num_triangles; ++ti) {
             struct BMLoop*(& triangle)[3] = triangles[ti];
 
+
             int material_index = 0;
             const int polygon_index = triangle[0]->f->head.index;
             if (polygon_index < polygons.size())
@@ -1112,8 +1113,21 @@ void msblenContext::doExtractEditMeshData(msblenContextState& state, BlenderSync
         size_t ii = 0;
         for (size_t ti = 0; ti < num_triangles; ++ti) {
             struct BMLoop*(& triangle)[3] = triangles[ti];
-            for (struct BMLoop* idx : triangle)
-                dst.normals[ii++] = -bl::BM_loop_calc_face_normal(*idx);
+            const int polygon_index = triangle[0]->f->head.index;
+
+            auto polygon = polygons[polygon_index];
+            auto smooth = polygon->head.hflag & BM_ELEM_SMOOTH;
+
+            for (struct BMLoop* idx : triangle) {
+                if (smooth) {
+                    auto index =  idx->v->head.index;
+                    auto vertext = vertices[index];
+                    dst.normals[ii++] = to_float3(vertext->no);
+                }
+                else {
+                    dst.normals[ii++] = to_float3(idx->f->no);
+                }
+            }
         }
     }
 


### PR DESCRIPTION
In edit mode, we currently recalculate the normals we export, ignoring the smooth setting for each polygon. The fix is to lookup the corresponding polygon for each triangle, and based on the smooth flag, either use the vertex normal or the face normal.

This is fixing the issue with broken normals in edit mode, reported here https://github.com/unity3d-jp/MeshSync/issues/768

Demo of the fix:
![ShadeModeChangeEditMode](https://user-images.githubusercontent.com/51912249/206021057-fabb8421-9437-45c7-b43a-4d929161b144.gif)
