### PR TITLE
blender: bake modifiers in Edit Mode

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
@@ -730,8 +730,7 @@ ms::MeshPtr msblenContext::exportMesh(msblenContextState& state, msblenContextPa
     msblenEntityHandler::extractTransformData(settings, src, dst);
 
     if (settings.sync_meshes) {
-        const bool need_convert = 
-            (!is_editing && settings.BakeModifiers ) || !is_mesh(src);
+        const bool need_convert = settings.BakeModifiers || !is_mesh(src);
 
         if (need_convert) {
             if (settings.BakeModifiers ) {
@@ -780,7 +779,7 @@ void msblenContext::doExtractMeshData(msblenContextState& state, BlenderSyncSett
 
         // on edit mode, editing is applied to EditMesh and base Mesh is intact. so get data from EditMesh on edit mode.
         // todo: Blender 2.8 displays transparent final mesh on edit mode. extract data from it.
-        if (is_editing) {
+        if (is_editing && !settings.BakeModifiers) {
             doExtractEditMeshData(state, settings, dst, obj, data);
         }
         else {

--- a/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
@@ -779,7 +779,7 @@ void msblenContext::doExtractMeshData(msblenContextState& state, BlenderSyncSett
 
         // on edit mode, editing is applied to EditMesh and base Mesh is intact. so get data from EditMesh on edit mode.
         // todo: Blender 2.8 displays transparent final mesh on edit mode. extract data from it.
-        if (is_editing && !settings.BakeModifiers) {
+        if (is_editing) {
             doExtractEditMeshData(state, settings, dst, obj, data);
         }
         else {


### PR DESCRIPTION
This PR takes into account the Bake modifier flag when the user is in Edit Mode.
Demo:
![BakeModsEditMode](https://user-images.githubusercontent.com/51912249/206216911-de048dad-fa82-4854-8b5e-df4a83b56289.gif)
