### PR TITLE
blender-fix: dangling pointers on Mesh data

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
@@ -443,8 +443,7 @@ ms::TransformPtr msblenContext::exportReference(msblenContextState& state, msble
 
             auto do_merge = [this, dst, &dst_mesh, &src_mesh, &settings, &state]() {
                 dst_mesh.merge(src_mesh);
-                if (settings.ExportSceneCache)
-                    dst_mesh.detach();
+                dst_mesh.detach();
                 dst_mesh.refine_settings = src_mesh.refine_settings;
                 dst_mesh.refine_settings.local2world = dst_mesh.world_matrix;
                 dst_mesh.refine_settings.flags.Set(ms::MESH_REFINE_FLAG_LOCAL2WORLD, true);


### PR DESCRIPTION
This PR fixes a 100% repro crash of the Editor when baking transforms in files with references in Blender. The issue seems to be that we share the ownership of mesh data, specifically the counts vector, and this vector is modified somewhere before we serialize it. The solution is to "detach" the reference merge from the shared data, which will create a deep copy of the buffers. A few points about the issue:

- The solution could slow down the export and increase memory usage but it will stop crashing the Editor.
- This bug could potentially corrupt all mesh data, not just counts.
- The editor crash happens because the counts buffer values are used for indexing in other mesh data buffers during mesh refinement, leading to a crash on the Server. 

I think the real root cause might be the SharedVector implementation. We avoid deallocating data when we are sharing. We check that by checking the m_shared_data pointer.
```
    bool is_shared() const
    {
        return m_shared_data != nullptr;
    }

    void shrink_to_fit()
    {
        if (is_shared()) // return if data is shared
            return;

        if (m_size == 0) {
            deallocate(m_data, m_size); // data is deallocated here
            m_data = nullptr;
            m_size = m_capacity = 0;
        }
        else if (m_size == m_capacity) {
            // nothing to do
            return;
        }
        else {
            size_t newsize = sizeof(T) * m_size;
            size_t oldsize = sizeof(T) * m_capacity;
            T *newdata = (T*)allocate(newsize);
            memcpy(newdata, m_data, newsize);
            deallocate(m_data, oldsize); // data is deallocated here
            m_data = newdata;
            m_capacity = m_size;
        }
    }
```

And the code for sharing data updates the shared data field for only one of the vectors:
```
    void share(const_pointer data, size_t size)
    {
        // just share data. no copy at this point.
        m_data = (pointer)data;
        m_shared_data = data;
        m_size = m_capacity = size;
    }
    void share(const RawVector<T, Align>& c)
    {
        share(c.cdata(), c.size());
    }
    void share(const SharedVector& c)
    {
        share(c.cdata(), c.size());
    }
```

So if we share vector A to B, 
A::m_data and A::m_shared_data point to B::m_data. 
B::m_shared_data is null.
and if we invoke shrink_to_fit on B, b will deallocate its m_data and A will be pointing to deallocated memory. Since the SharedVector code is used in more dcc tools, I would prefer to merge this PR to fix the current crashes and take more time to fix the actual root cause, while adding some unit tests.  