### PR TITLE
blender-fix: Fix for crashes when instantiating curves through geonodes

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/msblenContext.h
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContext.h
@@ -167,13 +167,13 @@ private:
 
 #if BLENDER_VERSION >= 300
     void exportInstances();
-    void exportInstances(Object* object, Object* parent, SharedVector<mu::float4x4>, mu::float4x4& inverse, msblenContextPathProvider& pathProvider);
+    void exportInstances(ms::TransformPtr transform, ms::TransformPtr parent, SharedVector<mu::float4x4>, mu::float4x4& inverse, msblenContextPathProvider& pathProvider);
 
     ms::InstanceInfoPtr exportInstanceInfo(
         msblenContextState& state,
         msblenContextPathProvider& paths,
-        Object* instancedObject,
-        Object* parent,
+        ms::TransformPtr transform,
+        ms::TransformPtr parent,
         SharedVector<mu::float4x4> mat);
 
 #endif

--- a/Plugins~/Src/MeshSyncClientBlender/msblenContextGeometryNodes.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContextGeometryNodes.cpp
@@ -8,13 +8,13 @@
 ms::InstanceInfoPtr msblenContext::exportInstanceInfo(
     msblenContextState& state,
     msblenContextPathProvider& paths,
-    Object* instancedObject,
-    Object* parent,
+    ms::TransformPtr transform,
+    ms::TransformPtr parent,
     SharedVector<mu::float4x4> mat) {
 
     auto info = ms::InstanceInfo::create();
-    info->path = paths.get_path(instancedObject);
-    info->parent_path = m_default_paths.get_path(parent); // parent will always be part of the scene
+    info->path = transform->path;
+    info->parent_path = parent->path; // parent will always be part of the scene
 
     info->transforms = std::move(mat);
 
@@ -27,42 +27,55 @@ void msblenContext::exportInstances() {
 
     blender::BlenderPyScene scene = blender::BlenderPyScene(blender::BlenderPyContext::get().scene());
 
-    std::unordered_set<Object*> scene_objects;
+    std::unordered_set<std::string> scene_objects;
     scene.each_objects([this, &scene_objects](Object* obj)
         {
-            scene_objects.insert(obj);
+            if (obj == nullptr || obj->data == nullptr)
+                return;
+
+            auto id = (ID*)obj->data;
+            scene_objects.insert(id->name + 2);
         });
 
     // Assume everything is now dirty
     m_instances_state->manager.setAlwaysMarkDirty(true);
 
-    m_geometryNodeUtils.each_instanced_object([this, &scene_objects](Object* instanced, Object* parent, SharedVector<mu::float4x4> matrices, bool fromFile) {
+    std::unordered_map<unsigned int, ms::TransformPtr> exportedTransforms;
 
-        auto settings = m_settings;
-        settings.BakeTransform = false;
+    m_geometryNodeUtils.each_instanced_object(
+        [this, &scene_objects, &exportedTransforms](blender::GeometryNodesUtils::Record& rec) {
+            auto obj = rec.obj;
+            if (!rec.from_file) {
+                auto settings = m_settings;
+                settings.BakeModifiers = false;
+                settings.multithreaded = false;
 
-        // There is some race condition that is causing rendering glitches on Unity. Seems related to UVs or triangle indices.
-        // Not using threads seems to fix it but should be investigated more.
-        settings.multithreaded = false;
+                auto transform = exportObject(*m_instances_state, m_intermediate_paths, settings, rec.obj, false, true);
+                transform->reset();
+                exportedTransforms[rec.id] = transform;
+            }
+            else if (scene_objects.find(rec.name) == scene_objects.end()) {
+                exportedTransforms[rec.id] = exportObject(*m_instances_state, m_default_paths, m_settings, rec.obj, false);
+            }
+            else {
+                exportedTransforms[rec.id] = exportObject(*m_entities_state, m_default_paths, m_settings, rec.obj, true, true);
+            }
+        },
+        [this, &exportedTransforms](blender::GeometryNodesUtils::Record& rec) {
+            auto world_matrix = msblenEntityHandler::getWorldMatrix(rec.parent);
+            auto inverse = mu::invert(world_matrix);
+            auto& transform = exportedTransforms[rec.id];
 
-        auto world_matrix = msblenEntityHandler::getWorldMatrix(parent);
-        auto inverse = mu::invert(world_matrix);
+            //parent is always part of the scene
+            auto& parent = exportObject(*m_entities_state, m_default_paths, m_settings, rec.parent, false);
 
-        // If the instanced object is not present in the file
-        if (!fromFile) {
-            settings.BakeModifiers = false;
-            auto transform = exportObject(*m_instances_state, m_intermediate_paths, settings, instanced, false);
-            transform->reset();
-            return exportInstances(instanced, parent, std::move(matrices), inverse, m_intermediate_paths);
-        }
-        
-        // check if the object has been already exported as part of the scene
-        auto scene_object = scene_objects.find(instanced);
-        if (scene_object == scene_objects.end()) {
-            exportObject(*m_instances_state, m_default_paths, settings, instanced, false);
-        }
-
-        return exportInstances(instanced, parent, std::move(matrices), inverse, m_default_paths);
+            if (rec.from_file) {
+                exportInstances(transform, parent, std::move(rec.matrices), inverse, m_default_paths);
+            }
+            else {
+                exportInstances(transform, parent, std::move(rec.matrices), inverse, m_intermediate_paths);
+            }
+            
         });
 
     m_geometryNodeUtils.setInstancesDirty(false);
@@ -70,14 +83,14 @@ void msblenContext::exportInstances() {
     scene_objects.clear();
 }
 
-void msblenContext::exportInstances(Object* instancedObject, Object* parent, SharedVector<mu::float4x4> mat, mu::float4x4& inverse, msblenContextPathProvider& pathProvider)
+void msblenContext::exportInstances(ms::TransformPtr transform, ms::TransformPtr parent, SharedVector<mu::float4x4> mat, mu::float4x4& inverse, msblenContextPathProvider& pathProvider)
 {
     mu::parallel_for(0, mat.size(), 10, [&](int i)
         {
-            mat[i] = m_geometryNodeUtils.blenderToUnityWorldMatrix(instancedObject, mat[i] * inverse);
+            mat[i] = m_geometryNodeUtils.blenderToUnityWorldMatrix(transform, mat[i] * inverse);
         });
 
-    exportInstanceInfo(*m_instances_state, pathProvider, instancedObject, parent, std::move(mat));
+    exportInstanceInfo(*m_instances_state, pathProvider, transform, parent, std::move(mat));
 }
 
 #endif

--- a/Plugins~/Src/MeshSyncClientBlender/msblenContextGeometryNodes.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContextGeometryNodes.cpp
@@ -55,7 +55,10 @@ void msblenContext::exportInstances() {
                 exportedTransforms[rec.id] = transform;
             }
             else if (scene_objects.find(rec.name) == scene_objects.end()) {
-                exportedTransforms[rec.id] = exportObject(*m_instances_state, m_default_paths, m_settings, rec.obj, false);
+                auto settings = m_settings;
+                settings.multithreaded = false;
+                settings.BakeModifiers = false;
+                exportedTransforms[rec.id] = exportObject(*m_instances_state, m_default_paths, settings, rec.obj, false, true);
             }
             else {
                 exportedTransforms[rec.id] = exportObject(*m_entities_state, m_default_paths, m_settings, rec.obj, true, true);

--- a/Plugins~/Src/MeshSyncClientBlender/msblenContextIntermediatePathProvider.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContextIntermediatePathProvider.cpp
@@ -31,8 +31,5 @@ std::string msblenContextIntermediatePathProvider::get_path(const Object* obj, c
         path = "/" + msblenUtils::get_name(obj);
     }
 
-    auto data = (ID*)obj->data;
-    auto name = std::string(data->name);
-
     return append_id(path, obj);
 }

--- a/Plugins~/Src/MeshSyncClientBlender/msblenContextState.h
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContextState.h
@@ -32,7 +32,7 @@ public:
     };
 
     std::set<const Object*> pending;
-    std::map<const void*, msblenContextState::ObjectRecord> records;
+    std::map<std::string, msblenContextState::ObjectRecord> records;
     std::map<Bone*, ms::TransformPtr> bones;
 
     ms::ITransformManager& manager;

--- a/Plugins~/Src/MeshSyncClientBlender/msblenEntityHandler.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenEntityHandler.cpp
@@ -22,7 +22,12 @@ static inline mu::float4x4 camera_correction(const mu::float4x4& v)
 
 void msblenEntityHandler::applyCorrectionIfNeeded(const Object* obj, mu::float4x4& matrix)
 {
-    if (is_camera(obj) || is_light(obj)) {
+    applyCorrectionIfNeeded(matrix, is_camera(obj), is_light(obj));
+}
+
+void msblenEntityHandler::applyCorrectionIfNeeded(mu::float4x4& matrix, bool is_camera, bool is_light) {
+
+    if (is_camera || is_light) {
         // Cameras and lights point towards their negative z in blender, in Unity they point in positive Z, correct for this:
         matrix = camera_correction(matrix);
     }

--- a/Plugins~/Src/MeshSyncClientBlender/msblenEntityHandler.h
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenEntityHandler.h
@@ -37,5 +37,6 @@ public:
 	static void extract_bone_trs(const mu::float4x4& mat, mu::float3& t, mu::quatf& r, mu::float3& s);
 
 	static void applyCorrectionIfNeeded(const Object* obj, mu::float4x4& matrix);
+	static void applyCorrectionIfNeeded(mu::float4x4& matrix, bool is_camera, bool is_light);
 };
 

--- a/Plugins~/Src/MeshSyncClientBlender/msblenGeometryNodeUtils.h
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenGeometryNodeUtils.h
@@ -18,6 +18,17 @@ public:
 
     GeometryNodesUtils();
 
+    struct Record {
+        Object* parent = nullptr;
+        Object* obj = nullptr;
+        SharedVector<mu::float4x4> matrices;
+        bool handled_matrices = false;
+        bool handled_object = false;
+        bool from_file = false;
+        std::string name;
+        unsigned int id;
+    };
+
     /// <summary>
     /// Invokes the handler function for each instance.
     /// </summary>
@@ -37,12 +48,14 @@ public:
     /// parent is the object that has the geometry node modifier.
     /// transforms is the collection of transforms for the instanced object.
     /// </param>
-    void each_instanced_object(std::function<void(Object*, Object*, SharedVector<mu::float4x4>, bool)> handler);
+    void each_instanced_object(
+        std::function<void(GeometryNodesUtils::Record& rec)> object_handler,
+        std::function<void(GeometryNodesUtils::Record& rec)> matrix_handler);
 
     /// <summary>
     /// Converts the world matrix from blender to Unity coordinate system
     /// </summary>
-    mu::float4x4 blenderToUnityWorldMatrix(const Object* obj, const mu::float4x4& blenderMatrix) const;
+    mu::float4x4 blenderToUnityWorldMatrix(ms::TransformPtr transform, const mu::float4x4& blenderMatrix) const;
     
     void setInstancesDirty(bool dirty);
     bool getInstancesDirty();
@@ -53,14 +66,6 @@ private:
     mu::float4x4 m_blender_to_unity_local;
     mu::float4x4 m_blender_to_unity_world;
     mu::float4x4 m_camera_light_correction;
-        
-    struct Record {
-        Object object_copy;
-        Object* parent = nullptr;
-        SharedVector<mu::float4x4> matrices;
-        bool handled = false;
-        bool updated = false;
-    };
 };
 
 


### PR DESCRIPTION
This PR cleans some tech debt we have in geonodes. With the recent work done to support any object and not just Meshes, a bug from an pre-existing hack I had introduced has come to surface. Specifically this line:
`std::memcpy(&rec.object_copy, obj, sizeof(Object));`
does a bitwise copy on the Object that is instantiated. There are 2 issues with this:
1. This operation is unsafe. obj could be using padding bytes
2. We copy pointers which may end up pointing to released or changed memory.

While this has worked for Meshes so far, I started noticing crashes when synching files with curves.

The fix is to refactor the code and instead of copying the object that is references, export it immediately.