### PR TITLE
blender: geometry node fixes

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/msblenContextGeometryNodes.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContextGeometryNodes.cpp
@@ -40,7 +40,7 @@ void msblenContext::exportInstances() {
     // Assume everything is now dirty
     m_instances_state->manager.setAlwaysMarkDirty(true);
 
-    std::unordered_map<unsigned int, ms::TransformPtr> exportedTransforms;
+    std::unordered_map<std::string, ms::TransformPtr> exportedTransforms;
 
     m_geometryNodeUtils.each_instanced_object(
         [this, &scene_objects, &exportedTransforms](blender::GeometryNodesUtils::Record& rec) {

--- a/Plugins~/Src/MeshSyncClientBlender/msblenGeometryNodeUtils.h
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenGeometryNodeUtils.h
@@ -26,7 +26,7 @@ public:
         bool handled_object = false;
         bool from_file = false;
         std::string name;
-        unsigned int id;
+        std::string id;
     };
 
     /// <summary>

--- a/Plugins~/Src/MeshSyncClientBlender/msblenGeometryNodesUtils.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenGeometryNodesUtils.cpp
@@ -80,7 +80,8 @@ namespace blender {
         std::function<void(Record&)> obj_handler,
         std::function<void(Record&)> matrix_handler) {
 
-        std::unordered_map<unsigned int, Record> records;
+        std::unordered_map<unsigned int, Record> records_by_session_id;
+        std::unordered_map<std::string, Record> records_by_name;
 
         // Collect object names in the file
         auto ctx = blender::BlenderPyContext::get();
@@ -99,7 +100,12 @@ namespace blender {
         each_instance([&](Object* obj, Object* parent, float4x4 matrix)
             {
                 auto id = (ID*)obj->data;
-                auto& rec = records[id->session_uuid];
+
+                //Some objects, i.e. lights, do not use a session uuid.
+                bool useName = id->session_uuid == 0;
+
+                auto& rec = useName? records_by_name[id->name + 2] : records_by_session_id[id->session_uuid];
+
                 if (!rec.handled_object)
                 {
                     rec.handled_object = true;
@@ -107,7 +113,7 @@ namespace blender {
                     rec.obj = obj;
                     rec.parent = parent;
                     rec.from_file = file_objects.find(rec.name) != file_objects.end();
-                    rec.id = id->session_uuid;
+                    rec.id = rec.name + "_" + std::to_string(id->session_uuid);
                     obj_handler(rec);
                 }
                 
@@ -117,7 +123,15 @@ namespace blender {
 
 
             // Export transforms
-            for (auto& rec : records) {
+            for (auto& rec : records_by_session_id) {
+                if (rec.second.handled_matrices)
+                    continue;
+
+                rec.second.handled_matrices = true;
+                matrix_handler(rec.second);
+            }
+
+            for (auto& rec : records_by_name) {
                 if (rec.second.handled_matrices)
                     continue;
 


### PR DESCRIPTION
Fixes for:
session_uuid being 0 in some cases.
naming clash between geonode mesh primitives and scene meshes.