### PR TITLE
blender: Multiple UVs in Edit mode

### DIFF
--- a/Plugins~/Src/MeshSyncClientBlender/msblenBinder.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenBinder.cpp
@@ -507,8 +507,16 @@ barray_range<BMTriangle> BEditMesh::triangles()
     return barray_range<BMTriangle> { m_ptr->looptris, (size_t)m_ptr->tottri };
 }
 
-int BEditMesh::uv_data_offset() const
+int BEditMesh::uv_data_offset(int index) const
 {
+    int layer_index = CustomData_get_layer_index_n(&m_ptr->bm->ldata, CD_MLOOPUV, index);
+    if (layer_index == -1) {
+        return NULL;
+    }
+
+    auto layer = m_ptr->bm->ldata.layers[layer_index];
+    return layer.offset;
+
     return CustomData_get_offset(m_ptr->bm->ldata, CD_MLOOPUV);
 }
 

--- a/Plugins~/Src/MeshSyncClientBlender/msblenBinder.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenBinder.cpp
@@ -516,8 +516,6 @@ int BEditMesh::uv_data_offset(int index) const
 
     auto layer = m_ptr->bm->ldata.layers[layer_index];
     return layer.offset;
-
-    return CustomData_get_offset(m_ptr->bm->ldata, CD_MLOOPUV);
 }
 
 MLoopUV* BEditMesh::GetUV(const int index) const {

--- a/Plugins~/Src/MeshSyncClientBlender/msblenBinder.h
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenBinder.h
@@ -139,10 +139,13 @@ namespace blender
         barray_range<BMFace*> polygons();
         barray_range<BMVert*> vertices();
         barray_range<BMTriangle> triangles();
-        int uv_data_offset() const;
+        int uv_data_offset(int index) const;
+        inline uint32_t GetNumUVs() const;
 
         MLoopUV* GetUV(const int index) const;
     };
+
+    uint32_t BEditMesh::GetNumUVs() const { return CustomData_number_of_layers(&m_ptr->bm->ldata, CD_MLOOPUV); }
 
     //----------------------------------------------------------------------------------------------------------------------
     

--- a/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
@@ -1129,16 +1129,23 @@ void msblenContext::doExtractEditMeshData(msblenContextState& state, BlenderSync
         }
     }
 
-    // uv
     if (settings.sync_uvs) {
-        const int offset = emesh.uv_data_offset();
-        if (offset != -1) {
-            dst.m_uv[0].resize_discard(num_indices);
+        
+        const int num_uv_layers = std::min(emesh.GetNumUVs(), ms::MeshSyncConstants::MAX_UV);
+
+        for (auto layerIndex = 0; layerIndex < num_uv_layers; layerIndex++) {
+            
+            const int offset = emesh.uv_data_offset(layerIndex);
+
+            if (offset == -1)
+                continue;
+
+            dst.m_uv[layerIndex].resize_discard(num_indices);
             size_t ii = 0;
             for (size_t ti = 0; ti < num_triangles; ++ti) {
                 auto& triangle = triangles[ti];
-                for (auto *idx : triangle)
-                    dst.m_uv[0][ii++] = *reinterpret_cast<mu::float2*>((char*)idx->head.data + offset);
+                for (auto* idx : triangle)
+                    dst.m_uv[layerIndex][ii++] = *reinterpret_cast<mu::float2*>((char*)idx->head.data + offset);
             }
         }
     }


### PR DESCRIPTION
Currently, when in edit mode, only one UV layer is exported. Made necessary changes to support multiple uv layers. 

Demo
![EditModeMultipleUVs](https://user-images.githubusercontent.com/51912249/211880407-147ae40a-f1ab-4ed6-bb28-e2b345c9704a.gif)
