### PR TITLE
blender-chore: remove 3.4.1 build optional argument for Blender

### DIFF
--- a/Plugins~/Docs/en/MakeOptionalArguments.md
+++ b/Plugins~/Docs/en/MakeOptionalArguments.md
@@ -46,7 +46,6 @@ with commands described in the following sections.
 * Blender 3.2.0 : `-DBUILD_BLENDER_3.2.0_PLUGIN=ON`
 * Blender 3.3.0 : `-DBUILD_BLENDER_3.3.0_PLUGIN=ON`
 * Blender 3.4.0 : `-DBUILD_BLENDER_3.4.0_PLUGIN=ON`
-* Blender 3.4.1 : `-DBUILD_BLENDER_3.4.1_PLUGIN=ON`
 
 ## Modo
 


### PR DESCRIPTION
The argument has no effect as we don't build a separate project for Blender 3.4.1