### PR TITLE
blender-fix: crash fix when removing an empty instance object

### DIFF
--- a/Plugins~/Src/MeshSyncClient/msInstancesManager.cpp
+++ b/Plugins~/Src/MeshSyncClient/msInstancesManager.cpp
@@ -85,7 +85,9 @@ namespace ms {
     {
         for (auto it = m_records.begin(); it != m_records.end(); ) {
             if (!it->second.updated) {
-                m_deleted.push_back(it->second.instances->getIdentifier());
+                if (it->second.instances) {
+                    m_deleted.push_back(it->second.instances->getIdentifier());
+                }
                 m_records.erase(it++);
             }
             else

--- a/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
+++ b/Plugins~/Src/MeshSyncClientBlender/msblenContext.cpp
@@ -928,7 +928,7 @@ void msblenContext::doExtractNonEditMeshData(msblenContextState& state, BlenderS
 
             // Material indices can be out of range if materials are removed.
             // Check for it so we don't crash when this happens:
-            material_index = min(material_index, materialCount - 1);
+            material_index = max(0, min(material_index, materialCount - 1));
 
             const int count = polygon.totloop;
             dst.counts[pi] = count;


### PR DESCRIPTION
fix: Fix for crash when removing empty instance object.